### PR TITLE
Fix typo in header. Update DecisionTaskHandler config

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,8 +1,8 @@
-Red Had Process Automation Manager - Order Management Demo Repository
+Red Hat Process Automation Manager - Order Management Demo Repository
 =====================================================================
 
 
-**Red Had Process Automation Manager** is the Business Process Management product from Red Hat, based on the open source project [jBPM](http://www.jbpm.org).
+**Red Hat Process Automation Manager** is the Business Process Management product from Red Hat, based on the open source project [jBPM](http://www.jbpm.org).
 
 This demo aims to show some of the core capabilities of this powerful product.
 

--- a/src/main/resources/META-INF/kie-deployment-descriptor.xml
+++ b/src/main/resources/META-INF/kie-deployment-descriptor.xml
@@ -18,7 +18,7 @@
     <work-item-handlers>
         <work-item-handler>
             <resolver>mvel</resolver>
-            <identifier>new org.jbpm.process.workitem.bpmn2.DecisionTaskHandler("com.demo", "order-management-dmn", "1.0.0-SNAPSHOT",15000)</identifier>
+            <identifier>new org.jbpm.process.workitem.bpmn2.DecisionTaskHandler("com.example", "order-management", "1.1-SNAPSHOT",15000)</identifier>
             <parameters />
             <name>DecisionTask</name>
         </work-item-handler>


### PR DESCRIPTION
Header says "Red Had" changed to "Red Hat".

More functionally, the configuration of DecisionTaskHandler points to a kie module that won't exist in a clean environment. Updated to match current GAV in pom.xml.